### PR TITLE
feat: Start react view is now responsive

### DIFF
--- a/thyrel-web/src/components/GameBar.tsx
+++ b/thyrel-web/src/components/GameBar.tsx
@@ -2,6 +2,8 @@ import PlayerCount from './room/PlayerCount';
 import AppTitle from './lobby/AppTitle';
 import StepTimer from './room/StepTimer';
 import Box from '../styles/Box';
+import { css } from '@emotion/css';
+import Mq from '../styles/breakpoint';
 
 type GameBarProps = {
   count: number;
@@ -19,17 +21,42 @@ export default function GameBar({
   onFinish,
 }: GameBarProps) {
   return (
-    <Box flexDirection="row" width="100%">
-      <PlayerCount count={count} max={max} />
-
+    <Box
+      className={css({
+        flexDirection: 'column',
+        alignItems: 'center',
+      })}
+      width="100%">
       <AppTitle />
 
-      <Box display="block" width={100} height={100}>
-        <StepTimer
-          finishAt={finishAt}
-          timeDuration={timeDuration}
-          onFinish={onFinish}
-        />
+      <Box
+        className={css({
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          width: '100%',
+          [Mq.SM]: {
+            position: 'relative',
+            top: '-64px',
+          },
+        })}>
+        <PlayerCount count={count} max={max} />
+
+        <Box
+          display="block"
+          className={css({
+            height: 64,
+            width: 64,
+            [Mq.SM]: {
+              height: 100,
+              width: 100,
+            },
+          })}>
+          <StepTimer
+            finishAt={finishAt}
+            timeDuration={timeDuration}
+            onFinish={onFinish}
+          />
+        </Box>
       </Box>
     </Box>
   );

--- a/thyrel-web/src/components/room/StepTimer.tsx
+++ b/thyrel-web/src/components/room/StepTimer.tsx
@@ -1,6 +1,8 @@
 import { Progress } from 'rsuite';
 import { baseColor } from '../../styles/colors';
 import React from 'react';
+import { useMediaQuery } from '../../hooks/useMediaQuery';
+import { MediaQuery } from '../../styles/breakpoint';
 
 type StepTimerProps = {
   finishAt: Date;
@@ -14,6 +16,7 @@ export default function StepTimer({
   onFinish,
 }: StepTimerProps) {
   const [progress, setProgress] = React.useState(0);
+  const isDeviceSM = useMediaQuery(MediaQuery.SM);
   const [timerInterval, setTimerInterval] = React.useState<NodeJS.Timeout>();
 
   React.useEffect(() => {
@@ -38,7 +41,7 @@ export default function StepTimer({
       strokeColor={baseColor}
       percent={progress}
       showInfo={progress >= 100}
-      strokeWidth={12}
+      strokeWidth={isDeviceSM ? 12 : 6}
       status={progress >= 100 ? 'success' : 'active'}
     />
   );

--- a/thyrel-web/src/pages/room/Start.tsx
+++ b/thyrel-web/src/pages/room/Start.tsx
@@ -7,7 +7,7 @@ import GameBar from '../../components/GameBar';
 
 export default function Start() {
   return (
-    <Box padding="25px" flexDirection="column" gap={42}>
+    <Box padding={32} flexDirection="column" gap={42}>
       <GameBar
         count={6}
         max={7}
@@ -30,7 +30,7 @@ export default function Start() {
       </Box>
 
       <Box gap={16} flexDirection="column" alignItems="center">
-        <BigInput value={'A grandma ate my father'} icon="edit" />
+        <BigInput placeholder="A grandma ate my father" icon="edit" />
         <BigButton icon="check">Save</BigButton>
       </Box>
     </Box>

--- a/thyrel-web/src/setupTests.ts
+++ b/thyrel-web/src/setupTests.ts
@@ -34,6 +34,19 @@ const localStorageMockStarter = function () {
 const localStorageMock = localStorageMockStarter();
 
 Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: any) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // Deprecated
+    removeListener: jest.fn(), // Deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }),
+});
 
 beforeAll(() => server.listen());
 


### PR DESCRIPTION
feat: Start react view is now responsive

- Modified GameBar
	- Component now "*folds*" when on mobile devices
	- Timer component modified
		- Timer shrinks in size
- Modified Start react view (BigInput has now a placeholder instead of a value, my bad)

## Desktop

![image](https://user-images.githubusercontent.com/50820503/109794531-3bd6f500-7c16-11eb-944b-7726cffd5241.png)

## Phone

<img src="https://user-images.githubusercontent.com/50820503/109794633-59a45a00-7c16-11eb-9ed2-37a5db293409.png" height="500px" />

CLOSE #148 